### PR TITLE
fix(#10): detect SPA navigation from Conversation/Commits tabs to Files Ch…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### About
 
-Git Well Soon is a Chrome extension (version 2.1.0.0) that automatically persists the 'Hide whitespace changes' setting when reviewing pull requests on GitHub and GitHub Enterprise instances.
+Git Well Soon is a Chrome extension that automatically persists the 'Hide whitespace changes' setting when reviewing pull requests on GitHub and GitHub Enterprise instances.
 
 The name is cheeky way of saying I hope GitHub will implement this feature themselves and make my extension obsolete, Git Well Soon!
 

--- a/content.js
+++ b/content.js
@@ -85,13 +85,14 @@ function updateLink(link) {
 }
 
 /**
- * Sets up a MutationObserver that is only active on relevant pages.
- * Disconnects the observer on navigation to non-relevant pages.
+ * Sets up a MutationObserver to detect SPA navigation and dynamically added links.
+ * Always observes, even on non-relevant pages, so it can detect GitHub's in-page
+ * navigation from tabs like Conversation/Commits to the Files Changed tab.
  * Debounces the callback to reduce performance impact.
  */
 function setupRelevantPageObserver() {
   addWhitespaceParam();
-  let oldHref = document.location.href;
+  let oldHref = window.location.href;
   const body = document.querySelector('body');
   let observerTimeout = null;
   let observer = null;
@@ -105,18 +106,13 @@ function setupRelevantPageObserver() {
       if (observerTimeout) clearTimeout(observerTimeout);
       observerTimeout = setTimeout(() => {
         log('MutationObserver callback', mutations.length, 'mutations');
-        if (oldHref !== document.location.href) {
-          oldHref = document.location.href;
-          log('URL changed', document.location.href);
+        if (oldHref !== window.location.href) {
+          oldHref = window.location.href;
+          log('URL changed', window.location.href);
           addWhitespaceParam();
-          // Only observe if new page is relevant
-          if (!isRelevantPage()) {
-            observer.disconnect();
-            observer = null;
-            log('Observer disconnected (irrelevant page)');
-            return;
-          }
         }
+        // Only process added links on relevant pages
+        if (!isRelevantPage()) return;
         for (const mutation of mutations) {
           for (const node of mutation.addedNodes) {
             if (node.nodeType === 1) {
@@ -136,10 +132,10 @@ function setupRelevantPageObserver() {
         }
       }, OBSERVER_DEBOUNCE_MS);
     });
-    if (isRelevantPage()) {
-      observer.observe(body, { childList: true, subtree: true });
-      log('Observer started (relevant page)');
-    }
+    // Always observe, even on non-relevant pages, so we can detect
+    // SPA navigation (e.g. Conversation tab -> Files Changed tab)
+    observer.observe(body, { childList: true, subtree: true });
+    log('Observer started');
   }
 
   startObserver();
@@ -263,5 +259,9 @@ if (typeof module !== 'undefined' && module.exports) {
     isGitHubSite,
     isRelevantPage,
     addWhitespaceParam,
+    setupRelevantPageObserver,
+    interceptLinkClicks,
+    updateLink,
+    isRelevantLink,
   };
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Git Well Soon",
   "description": "A lightweight Chrome extension to hide whitespace in GitHub",
-  "version": "2.1.0.0",
+  "version": "2.2.0.0",
   "manifest_version": 3,
   "icons": {
     "16": "assets/16x16.png",

--- a/test/spa-navigation.test.js
+++ b/test/spa-navigation.test.js
@@ -1,0 +1,304 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
+// Mock chrome storage API before importing content.js
+global.chrome = {
+  storage: {
+    sync: {
+      get: jest.fn((defaults, cb) => cb(defaults)),
+    },
+  },
+};
+
+const {
+  setupRelevantPageObserver,
+  interceptLinkClicks,
+  isRelevantLink,
+  updateLink,
+} = require('../content.js');
+
+// Mock replaceState and reload
+window.history.replaceState = jest.fn();
+
+describe('setupRelevantPageObserver - SPA navigation', () => {
+  let reloadMock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    reloadMock = jest.fn();
+    // Ensure body exists
+    document.body.innerHTML = '<div id="app"></div>';
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function setLocation(url) {
+    const parsed = new URL(url);
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: url,
+        pathname: parsed.pathname,
+        hostname: parsed.hostname,
+        search: parsed.search,
+        origin: parsed.origin,
+        reload: reloadMock,
+      },
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  it('should start observer even on non-relevant pages (Conversation tab)', () => {
+    setLocation('https://github.com/owner/repo/pull/123');
+
+    // Should not throw — observer should start even though page is not relevant
+    expect(() => setupRelevantPageObserver()).not.toThrow();
+
+    // replaceState should NOT be called since this is not a relevant page
+    expect(window.history.replaceState).not.toHaveBeenCalled();
+  });
+
+  it('should call addWhitespaceParam when URL changes to a relevant page', async () => {
+    // Start on Conversation tab (non-relevant)
+    setLocation('https://github.com/owner/repo/pull/123');
+    setupRelevantPageObserver();
+
+    expect(window.history.replaceState).not.toHaveBeenCalled();
+
+    // Simulate GitHub SPA navigation: URL changes to /files and DOM mutates
+    setLocation('https://github.com/owner/repo/pull/123/files');
+    document.body.appendChild(document.createElement('div'));
+
+    // Flush MutationObserver microtask, then advance past debounce (50ms)
+    await Promise.resolve();
+    jest.advanceTimersByTime(100);
+
+    // addWhitespaceParam should have been called (replaceState is its indicator)
+    expect(window.history.replaceState).toHaveBeenCalled();
+    const calledUrl = window.history.replaceState.mock.calls[0][2];
+    expect(calledUrl).toContain('/files');
+    expect(calledUrl).toContain('w=1');
+  });
+
+  it('should call addWhitespaceParam when URL changes to /changes page', async () => {
+    setLocation('https://github.com/owner/repo/pull/123');
+    setupRelevantPageObserver();
+
+    // Navigate to /changes via SPA
+    setLocation('https://github.com/owner/repo/pull/123/changes');
+    document.body.appendChild(document.createElement('span'));
+    await Promise.resolve();
+    jest.advanceTimersByTime(100);
+
+    expect(window.history.replaceState).toHaveBeenCalled();
+    const calledUrl = window.history.replaceState.mock.calls[0][2];
+    expect(calledUrl).toContain('/changes');
+    expect(calledUrl).toContain('w=1');
+  });
+
+  it('should keep observing after navigating to a non-relevant page', async () => {
+    // Start on Files tab (relevant)
+    setLocation('https://github.com/owner/repo/pull/123/files?w=1');
+    setupRelevantPageObserver();
+    jest.clearAllMocks();
+
+    // SPA navigate to Conversation tab (non-relevant)
+    setLocation('https://github.com/owner/repo/pull/123');
+    document.body.appendChild(document.createElement('div'));
+    await Promise.resolve(); // flush MutationObserver microtask
+    jest.advanceTimersByTime(100);
+
+    // Should NOT call replaceState (non-relevant page)
+    expect(window.history.replaceState).not.toHaveBeenCalled();
+
+    // Now SPA navigate BACK to Files tab
+    setLocation('https://github.com/owner/repo/pull/123/files');
+    document.body.appendChild(document.createElement('div'));
+    await Promise.resolve(); // flush MutationObserver microtask
+    jest.advanceTimersByTime(100);
+
+    // Should call replaceState (relevant page, w=1 missing)
+    expect(window.history.replaceState).toHaveBeenCalled();
+    const calledUrl = window.history.replaceState.mock.calls[0][2];
+    expect(calledUrl).toContain('w=1');
+  });
+
+  it('should not call addWhitespaceParam if URL has not changed', async () => {
+    setLocation('https://github.com/owner/repo/pull/123/files?w=1');
+    setupRelevantPageObserver();
+    jest.clearAllMocks();
+
+    // DOM mutation without URL change
+    document.body.appendChild(document.createElement('div'));
+    await Promise.resolve();
+    jest.advanceTimersByTime(100);
+
+    // replaceState should NOT be called (w=1 already present)
+    expect(window.history.replaceState).not.toHaveBeenCalled();
+  });
+
+  it('should handle Conversation -> Commits -> Files SPA navigation', async () => {
+    // Start on Conversation tab
+    setLocation('https://github.com/owner/repo/pull/123');
+    setupRelevantPageObserver();
+
+    // SPA navigate to Commits tab (non-relevant for w=1)
+    setLocation('https://github.com/owner/repo/pull/123/commits');
+    document.body.appendChild(document.createElement('div'));
+    await Promise.resolve(); // flush MutationObserver microtask
+    jest.advanceTimersByTime(100);
+    jest.clearAllMocks();
+
+    // SPA navigate to Files tab
+    setLocation('https://github.com/owner/repo/pull/123/files');
+    document.body.appendChild(document.createElement('div'));
+    await Promise.resolve(); // flush MutationObserver microtask
+    jest.advanceTimersByTime(100);
+
+    expect(window.history.replaceState).toHaveBeenCalled();
+    const calledUrl = window.history.replaceState.mock.calls[0][2];
+    expect(calledUrl).toContain('/files');
+    expect(calledUrl).toContain('w=1');
+  });
+});
+
+describe('interceptLinkClicks - SPA link updates', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    Object.defineProperty(window, 'location', {
+      value: new URL('https://github.com/owner/repo/pull/123'),
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('should add w=1 to a clicked relevant link', () => {
+    interceptLinkClicks();
+
+    const link = document.createElement('a');
+    link.href = 'https://github.com/owner/repo/pull/123/files';
+    document.body.appendChild(link);
+
+    link.click();
+
+    const url = new URL(link.href);
+    expect(url.searchParams.get('w')).toBe('1');
+  });
+
+  it('should not modify a clicked non-relevant link', () => {
+    interceptLinkClicks();
+
+    const link = document.createElement('a');
+    link.href = 'https://github.com/owner/repo/pull/123';
+    document.body.appendChild(link);
+
+    const originalHref = link.href;
+    link.click();
+
+    expect(link.href).toBe(originalHref);
+  });
+
+  it('should not modify link if w=1 is already present', () => {
+    interceptLinkClicks();
+
+    const link = document.createElement('a');
+    link.href = 'https://github.com/owner/repo/pull/123/files?w=1';
+    document.body.appendChild(link);
+
+    const originalHref = link.href;
+    link.click();
+
+    expect(link.href).toBe(originalHref);
+  });
+
+  it('should not modify link if w=0 is explicitly set', () => {
+    interceptLinkClicks();
+
+    const link = document.createElement('a');
+    link.href = 'https://github.com/owner/repo/pull/123/files?w=0';
+    document.body.appendChild(link);
+
+    const originalHref = link.href;
+    link.click();
+
+    expect(link.href).toBe(originalHref);
+  });
+});
+
+describe('updateLink', () => {
+  it('should add w=1 to a relevant link', () => {
+    const link = document.createElement('a');
+    link.href = 'https://github.com/owner/repo/pull/123/files';
+    updateLink(link);
+    expect(new URL(link.href).searchParams.get('w')).toBe('1');
+  });
+
+  it('should not modify a link that already has w=1', () => {
+    const link = document.createElement('a');
+    link.href = 'https://github.com/owner/repo/pull/123/files?w=1';
+    const original = link.href;
+    updateLink(link);
+    expect(link.href).toBe(original);
+  });
+
+  it('should not modify a non-relevant link', () => {
+    const link = document.createElement('a');
+    link.href = 'https://github.com/owner/repo/pull/123';
+    const original = link.href;
+    updateLink(link);
+    expect(link.href).toBe(original);
+  });
+
+  it('should add w=1 to /changes link', () => {
+    const link = document.createElement('a');
+    link.href = 'https://github.com/owner/repo/pull/456/changes';
+    updateLink(link);
+    expect(new URL(link.href).searchParams.get('w')).toBe('1');
+  });
+});
+
+describe('isRelevantLink', () => {
+  it('should match /pull/N/files links', () => {
+    const link = document.createElement('a');
+    link.href = 'https://github.com/owner/repo/pull/123/files';
+    expect(isRelevantLink(link)).toBe(true);
+  });
+
+  it('should match /pull/N/changes links', () => {
+    const link = document.createElement('a');
+    link.href = 'https://github.com/owner/repo/pull/123/changes';
+    expect(isRelevantLink(link)).toBe(true);
+  });
+
+  it('should not match PR conversation links', () => {
+    const link = document.createElement('a');
+    link.href = 'https://github.com/owner/repo/pull/123';
+    expect(isRelevantLink(link)).toBe(false);
+  });
+
+  it('should match /compare/ links', () => {
+    const link = document.createElement('a');
+    link.href = 'https://github.com/owner/repo/compare/main...feature';
+    expect(isRelevantLink(link)).toBe(true);
+  });
+
+  it('should match /commit/ links', () => {
+    const link = document.createElement('a');
+    link.href = 'https://github.com/owner/repo/commit/abc123';
+    expect(isRelevantLink(link)).toBe(true);
+  });
+
+  it('should not match unrelated GitHub links', () => {
+    const link = document.createElement('a');
+    link.href = 'https://github.com/owner/repo/issues/123';
+    expect(isRelevantLink(link)).toBe(false);
+  });
+});


### PR DESCRIPTION
…anged

The MutationObserver was only started on relevant pages (files/changes), so GitHub's in-page navigation from other PR tabs was invisible to the extension. Now the observer always runs, detects the URL change, and applies w=1 after SPA navigation.